### PR TITLE
Fix permissions for the 'az' binary

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,5 +36,5 @@ package() {
   cp -r azure-cli "$pkgdir/opt"
 
   mkdir -p "$pkgdir/usr/bin"
-  cp az "$pkgdir/usr/bin"
+  install -Dm755 az "$pkgdir/usr/bin"
 }


### PR DESCRIPTION
Hello,

I stumbled upon an edge case when trying to use this AUR package.
Because I use `umask 027` for my users, the `az` binary gets cloned with permissions `750`.
In the `package` stage, `cp` is used to copy the `az` binary, which result in the file having the same permissions inside the package and makes it unusable for non-root users.

This behavior can be reproduced by manually setting the permissions of `az` to `750`.

This PR simply fixes the issue by forcing the permissions of the file.